### PR TITLE
Fixes compiliation, fixes panic on missing args for subcommands.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,16 +1,3 @@
-[root]
-name = "canvas"
-version = "0.1.0"
-dependencies = [
- "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "adler32"
 version = "1.0.2"
@@ -71,6 +58,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "canvas"
+version = "0.1.0"
+dependencies = [
+ "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/commands/assignment.rs
+++ b/src/commands/assignment.rs
@@ -1,7 +1,7 @@
-mod clap;
+use clap;
 
-mod canvas;
-mod config;
+use super::super::canvas;
+use config;
 
 
 pub fn subcommand(matches: &clap::ArgMatches) -> Result<(), String> {

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,4 +1,5 @@
 use std;
+use std::io::{Read,Write};
 use clap;
 use toml;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,45 +45,55 @@ fn app<'a, 'b>() -> clap::App<'a, 'b> {
         (setting: clap::AppSettings::ArgRequiredElseHelp)
         (@subcommand course =>
             (about: "List courses and view course information")
+            (setting: clap::AppSettings::SubcommandRequiredElseHelp)
             (@subcommand ls =>
                 (about: "List courses")
             )
             (@subcommand info =>
                 (about: "Display information about a course")
+                (setting: clap::AppSettings::ArgRequiredElseHelp)
                 (@arg course: +required "A course title or numeric ID")
             )
         )
         (@subcommand file =>
             (about: "List, inspect, or download files")
+            (setting: clap::AppSettings::SubcommandRequiredElseHelp)
             (@subcommand ls =>
                 (about: "List files")
+                (setting: clap::AppSettings::SubcommandRequiredElseHelp)
                 (@arg course: +required "A course title or numeric ID")
                 (@arg path: "The directory to examine. Defaults to /")
             )
             (@subcommand info =>
                 (about: "Display information about a file")
+                (setting: clap::AppSettings::ArgRequiredElseHelp)
                 (@arg course: +required "A course title or numeric ID")
                 (@arg path: +required "The file or directory to examine")
             )
             (@subcommand download =>
                 (about: "Download a file")
+                (setting: clap::AppSettings::ArgRequiredElseHelp)
                 (@arg course: +required "A course title or numeric ID")
                 (@arg path: +required "The file or directory to download")
             )
         )
         (@subcommand assignment =>
             (about: "List, inspect, or submit assignments")
+            (setting: clap::AppSettings::SubcommandRequiredElseHelp)
             (@subcommand ls =>
                 (about: "List assignments")
+                (setting: clap::AppSettings::ArgRequiredElseHelp)
                 (@arg course: +required "A course title or numeric ID")
             )
             (@subcommand info =>
                 (about: "Display information about an assignment")
+                (setting: clap::AppSettings::ArgRequiredElseHelp)
                 (@arg course: +required "A course title or numeric ID")
                 (@arg id: +required "An assignment ID")
             )
             (@subcommand submit =>
                 (about: "Submit files for an assignment")
+                (setting: clap::AppSettings::ArgRequiredElseHelp)
                 (@arg course: +required "A course title or numeric ID")
                 (@arg id: +required "An assignment ID")
                 (@arg file: +required +multiple "The file to submit")


### PR DESCRIPTION
Closes #5 

To quote from the comment I made on the issue:
`The issue is that clap::AppSetting::ArgRequiredElseHelp doesn't propegate down to subcommands, so you need to specify it on each subcommand.`

I also fixed a few compiliation issues. (mainly changing `mod blah` to `use blah`)