### PR TITLE
Improve a few things surrounding config files.

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -126,6 +126,9 @@ pub fn subcommand(_matches: &clap::ArgMatches) -> Result<(), String> {
     // We have to allow this to fail in case it doesn't already exist
     let _ = std::fs::rename(&path, &backup_path);
 
+    std::fs::create_dir_all(&path.parent().unwrap())
+        .map_err(|err| format!("Error creating config dir ({})", err))?;
+
     let mut file = std::fs::OpenOptions::new()
         .write(true)
         .create(true)

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,7 +35,9 @@ pub fn config_path() -> Result<std::path::PathBuf, String> {
 
 pub fn config_file() -> Result<std::fs::File, String> {
     let path = config_path()?;
-    std::fs::File::open(path).map_err(|err| format!("Cannot open config file ({})", err))
+    std::fs::File::open(path)
+        .map_err(|err| format!("Config file doesn't appear to exist, try running {} config",
+                                std::env::current_exe().unwrap().to_string_lossy()))
 }
 
 pub fn get_config() -> Result<Config, String> {


### PR DESCRIPTION
Closes #8 by automatically creating the configuration directory with `create_dir_all`

Also changes the error message to say that the config file isn't present and indicate how to generate it.